### PR TITLE
[feature/api_mypage] 마이페이지 API 기본적인 툴 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,11 +20,6 @@
             android:label="@string/app_name"
             android:theme="@style/Theme.Meongmory">
 
-        </activity>
-        <activity
-            android:name="com.meongmoryteam.presentation.ui.splash.SplashActivity"
-            android:exported="true"
-            android:theme="@style/Theme.Meongmory">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -32,19 +27,12 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="com.meongmoryteam.presentation.ui.login.LoginActivity"
+            android:name="com.meongmoryteam.presentation.ui.splash.SplashActivity"
+            android:exported="true"
             android:theme="@style/Theme.Meongmory">
-
         </activity>
         <activity
-            android:name="com.meongmoryteam.presentation.ui.myPage.profile.MyPageProfileActivity"
-            android:exported="true"
-            android:theme="@style/Theme.Meongmory">
-
-        </activity>
-
-        <activity android:name="com.meongmoryteam.presentation.ui.myPage.question.MyPageQuestionActivity"
-            android:exported="true"
+            android:name="com.meongmoryteam.presentation.ui.login.LoginActivity"
             android:theme="@style/Theme.Meongmory">
 
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,17 +19,19 @@
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Meongmory">
-
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
         </activity>
         <activity
             android:name="com.meongmoryteam.presentation.ui.splash.SplashActivity"
             android:exported="true"
             android:theme="@style/Theme.Meongmory">
+
+
         </activity>
         <activity
             android:name="com.meongmoryteam.presentation.ui.login.LoginActivity"

--- a/app/src/main/java/com/meongmoryteam/meongmory/di/NetworkModule.kt
+++ b/app/src/main/java/com/meongmoryteam/meongmory/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.meongmoryteam.meongmory.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.meongmoryteam.data.service.login.LoginApi
+import com.meongmoryteam.data.service.logout.LogoutApi
 import com.meongmoryteam.data.service.mypage.MyPageApi
 import dagger.Module
 import dagger.Provides
@@ -58,5 +59,11 @@ object NetworkModule {
     @Singleton
     fun provideMyPageApi(retrofit: Retrofit): MyPageApi {
         return retrofit.create(MyPageApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideLogoutApi(retrofit: Retrofit): LogoutApi {
+        return retrofit.create(LogoutApi::class.java)
     }
 }

--- a/app/src/main/java/com/meongmoryteam/meongmory/di/NetworkModule.kt
+++ b/app/src/main/java/com/meongmoryteam/meongmory/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.meongmoryteam.meongmory.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.meongmoryteam.data.service.login.LoginApi
+import com.meongmoryteam.data.service.mypage.MyPageApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -11,6 +12,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import retrofit2.create
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -50,5 +52,11 @@ object NetworkModule {
     @Singleton
     fun provideLoginApi(retrofit: Retrofit): LoginApi {
         return retrofit.create(LoginApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideMyPageApi(retrofit: Retrofit): MyPageApi {
+        return retrofit.create(MyPageApi::class.java)
     }
 }

--- a/app/src/main/java/com/meongmoryteam/meongmory/di/RepositoryModule.kt
+++ b/app/src/main/java/com/meongmoryteam/meongmory/di/RepositoryModule.kt
@@ -41,5 +41,4 @@ abstract class RepositoryModule {
     abstract fun bindMyPageDataSource(
         myPageDataSourceImpl: MyPageDataSourceImpl
     ): MyPageDataSource
-
 }

--- a/app/src/main/java/com/meongmoryteam/meongmory/di/RepositoryModule.kt
+++ b/app/src/main/java/com/meongmoryteam/meongmory/di/RepositoryModule.kt
@@ -2,11 +2,15 @@ package com.meongmoryteam.meongmory.di
 
 import com.meongmoryteam.data.datasource.login.LoginDataSource
 import com.meongmoryteam.data.datasource.login.LoginDataSourceImpl
+import com.meongmoryteam.data.datasource.logout.LogoutDataSource
+import com.meongmoryteam.data.datasource.logout.LogoutDataSourceImpl
 import com.meongmoryteam.data.datasource.mypage.MyPageDataSource
 import com.meongmoryteam.data.datasource.mypage.MyPageDataSourceImpl
 import com.meongmoryteam.data.repository.login.LoginRepositoryImpl
+import com.meongmoryteam.data.repository.logout.LogoutRepositoryImpl
 import com.meongmoryteam.data.repository.mypage.MyPageRepositoryImpl
 import com.meongmoryteam.domain.repository.login.LoginRepository
+import com.meongmoryteam.domain.repository.logout.LogoutRepository
 import com.meongmoryteam.domain.repository.mypage.MyPageRepository
 import dagger.Binds
 import dagger.Module
@@ -41,4 +45,16 @@ abstract class RepositoryModule {
     abstract fun bindMyPageDataSource(
         myPageDataSourceImpl: MyPageDataSourceImpl
     ): MyPageDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindLogoutRepository(
+        logoutRepositoryImpl: LogoutRepositoryImpl
+    ): LogoutRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindLogoutDataSource(
+        logoutDataSourceImpl: LogoutDataSourceImpl
+    ): LogoutDataSource
 }

--- a/app/src/main/java/com/meongmoryteam/meongmory/di/RepositoryModule.kt
+++ b/app/src/main/java/com/meongmoryteam/meongmory/di/RepositoryModule.kt
@@ -2,8 +2,12 @@ package com.meongmoryteam.meongmory.di
 
 import com.meongmoryteam.data.datasource.login.LoginDataSource
 import com.meongmoryteam.data.datasource.login.LoginDataSourceImpl
+import com.meongmoryteam.data.datasource.mypage.MyPageDataSource
+import com.meongmoryteam.data.datasource.mypage.MyPageDataSourceImpl
 import com.meongmoryteam.data.repository.login.LoginRepositoryImpl
+import com.meongmoryteam.data.repository.mypage.MyPageRepositoryImpl
 import com.meongmoryteam.domain.repository.login.LoginRepository
+import com.meongmoryteam.domain.repository.mypage.MyPageRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -25,4 +29,16 @@ abstract class RepositoryModule {
     abstract fun bindLoginDataSource(
         loginDataSourceImpl: LoginDataSourceImpl
     ): LoginDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindMyPageRepository(
+        myPageRepositoryImpl: MyPageRepositoryImpl
+    ): MyPageRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindMyPageDataSource(
+        myPageDataSourceImpl: MyPageDataSourceImpl
+    ): MyPageDataSource
 }

--- a/app/src/main/java/com/meongmoryteam/meongmory/di/RepositoryModule.kt
+++ b/app/src/main/java/com/meongmoryteam/meongmory/di/RepositoryModule.kt
@@ -41,4 +41,5 @@ abstract class RepositoryModule {
     abstract fun bindMyPageDataSource(
         myPageDataSourceImpl: MyPageDataSourceImpl
     ): MyPageDataSource
+
 }

--- a/data/src/main/java/com/meongmoryteam/data/datasource/logout/LogoutDataSource.kt
+++ b/data/src/main/java/com/meongmoryteam/data/datasource/logout/LogoutDataSource.kt
@@ -1,7 +1,9 @@
 package com.meongmoryteam.data.datasource.logout
 
+import com.meongmoryteam.data.model.response.logout.DeleteUserResponse
 import com.meongmoryteam.data.model.response.logout.PostUserLogoutResponse
 
 interface LogoutDataSource {
     suspend fun postUserLogout(): Result<PostUserLogoutResponse>
+    suspend fun deleteUser(): Result<DeleteUserResponse>
 }

--- a/data/src/main/java/com/meongmoryteam/data/datasource/logout/LogoutDataSource.kt
+++ b/data/src/main/java/com/meongmoryteam/data/datasource/logout/LogoutDataSource.kt
@@ -1,0 +1,7 @@
+package com.meongmoryteam.data.datasource.logout
+
+import com.meongmoryteam.data.model.response.logout.PostUserLogoutResponse
+
+interface LogoutDataSource {
+    suspend fun postUserLogout(): Result<PostUserLogoutResponse>
+}

--- a/data/src/main/java/com/meongmoryteam/data/datasource/logout/LogoutDataSourceImpl.kt
+++ b/data/src/main/java/com/meongmoryteam/data/datasource/logout/LogoutDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.meongmoryteam.data.datasource.logout
 
+import com.meongmoryteam.data.model.response.logout.DeleteUserResponse
 import com.meongmoryteam.data.model.response.logout.PostUserLogoutResponse
 import com.meongmoryteam.data.service.logout.LogoutApi
 import javax.inject.Inject
@@ -9,5 +10,9 @@ class LogoutDataSourceImpl @Inject constructor(
 ): LogoutDataSource {
     override suspend fun postUserLogout(): Result<PostUserLogoutResponse> {
         return runCatching { logoutApi.postUserLogout() }
+    }
+
+    override suspend fun deleteUser(): Result<DeleteUserResponse> {
+        return runCatching { logoutApi.deleteUser() }
     }
 }

--- a/data/src/main/java/com/meongmoryteam/data/datasource/logout/LogoutDataSourceImpl.kt
+++ b/data/src/main/java/com/meongmoryteam/data/datasource/logout/LogoutDataSourceImpl.kt
@@ -1,0 +1,13 @@
+package com.meongmoryteam.data.datasource.logout
+
+import com.meongmoryteam.data.model.response.logout.PostUserLogoutResponse
+import com.meongmoryteam.data.service.logout.LogoutApi
+import javax.inject.Inject
+
+class LogoutDataSourceImpl @Inject constructor(
+    private val logoutApi: LogoutApi
+): LogoutDataSource {
+    override suspend fun postUserLogout(): Result<PostUserLogoutResponse> {
+        return runCatching { logoutApi.postUserLogout() }
+    }
+}

--- a/data/src/main/java/com/meongmoryteam/data/datasource/mypage/MyPageDataSource.kt
+++ b/data/src/main/java/com/meongmoryteam/data/datasource/mypage/MyPageDataSource.kt
@@ -1,0 +1,7 @@
+package com.meongmoryteam.data.datasource.mypage
+
+import com.meongmoryteam.data.model.response.mypage.GetUserMyPageResponse
+
+interface MyPageDataSource {
+    suspend fun getUserMyPage(): Result<GetUserMyPageResponse>
+}

--- a/data/src/main/java/com/meongmoryteam/data/datasource/mypage/MyPageDataSource.kt
+++ b/data/src/main/java/com/meongmoryteam/data/datasource/mypage/MyPageDataSource.kt
@@ -1,7 +1,11 @@
 package com.meongmoryteam.data.datasource.mypage
 
+import com.meongmoryteam.data.model.request.mypage.UserMyPageRequest
 import com.meongmoryteam.data.model.response.mypage.GetUserMyPageResponse
+import com.meongmoryteam.data.model.response.mypage.PatchUserMyPageResponse
 
 interface MyPageDataSource {
     suspend fun getUserMyPage(): Result<GetUserMyPageResponse>
+
+    suspend fun patchUserMyPage(userMyPageRequest: UserMyPageRequest): Result<PatchUserMyPageResponse>
 }

--- a/data/src/main/java/com/meongmoryteam/data/datasource/mypage/MyPageDataSourceImpl.kt
+++ b/data/src/main/java/com/meongmoryteam/data/datasource/mypage/MyPageDataSourceImpl.kt
@@ -14,6 +14,6 @@ class MyPageDataSourceImpl @Inject constructor(
     }
 
     override suspend fun patchUserMyPage(userMyPageRequest: UserMyPageRequest): Result<PatchUserMyPageResponse> {
-        return kotlin.runCatching { myPageApi.patchUserMyPage() }
+        return kotlin.runCatching { myPageApi.patchUserMyPage(userMyPageRequest) }
     }
 }

--- a/data/src/main/java/com/meongmoryteam/data/datasource/mypage/MyPageDataSourceImpl.kt
+++ b/data/src/main/java/com/meongmoryteam/data/datasource/mypage/MyPageDataSourceImpl.kt
@@ -1,6 +1,8 @@
 package com.meongmoryteam.data.datasource.mypage
 
+import com.meongmoryteam.data.model.request.mypage.UserMyPageRequest
 import com.meongmoryteam.data.model.response.mypage.GetUserMyPageResponse
+import com.meongmoryteam.data.model.response.mypage.PatchUserMyPageResponse
 import com.meongmoryteam.data.service.mypage.MyPageApi
 import javax.inject.Inject
 
@@ -9,5 +11,9 @@ class MyPageDataSourceImpl @Inject constructor(
 ): MyPageDataSource {
     override suspend fun getUserMyPage(): Result<GetUserMyPageResponse> {
         return kotlin.runCatching { myPageApi.getUserMyPage() }
+    }
+
+    override suspend fun patchUserMyPage(userMyPageRequest: UserMyPageRequest): Result<PatchUserMyPageResponse> {
+        return kotlin.runCatching { myPageApi.patchUserMyPage() }
     }
 }

--- a/data/src/main/java/com/meongmoryteam/data/datasource/mypage/MyPageDataSourceImpl.kt
+++ b/data/src/main/java/com/meongmoryteam/data/datasource/mypage/MyPageDataSourceImpl.kt
@@ -1,0 +1,13 @@
+package com.meongmoryteam.data.datasource.mypage
+
+import com.meongmoryteam.data.model.response.mypage.GetUserMyPageResponse
+import com.meongmoryteam.data.service.mypage.MyPageApi
+import javax.inject.Inject
+
+class MyPageDataSourceImpl @Inject constructor(
+    private val myPageApi: MyPageApi
+): MyPageDataSource {
+    override suspend fun getUserMyPage(): Result<GetUserMyPageResponse> {
+        return kotlin.runCatching { myPageApi.getUserMyPage() }
+    }
+}

--- a/data/src/main/java/com/meongmoryteam/data/model/request/logout/UserLogoutRequest.kt
+++ b/data/src/main/java/com/meongmoryteam/data/model/request/logout/UserLogoutRequest.kt
@@ -1,0 +1,4 @@
+package com.meongmoryteam.data.model.request.logout
+
+import kotlinx.serialization.Serializable
+

--- a/data/src/main/java/com/meongmoryteam/data/model/request/mypage/UserMyPageRequest.kt
+++ b/data/src/main/java/com/meongmoryteam/data/model/request/mypage/UserMyPageRequest.kt
@@ -1,0 +1,15 @@
+package com.meongmoryteam.data.model.request.mypage
+
+import com.meongmoryteam.domain.model.reqeust.mypage.UserMyPageRequestEntity
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserMyPageRequest(
+    val nickname: String
+)
+
+fun UserMyPageRequestEntity.toUserMyPageRequest(): UserMyPageRequest {
+    return UserMyPageRequest(
+        nickname = this.nickname
+    )
+}

--- a/data/src/main/java/com/meongmoryteam/data/model/response/logout/DeleteUserResponse.kt
+++ b/data/src/main/java/com/meongmoryteam/data/model/response/logout/DeleteUserResponse.kt
@@ -1,0 +1,29 @@
+package com.meongmoryteam.data.model.response.logout
+
+import com.meongmoryteam.domain.model.response.logout.DeleteUser
+import com.meongmoryteam.domain.model.response.logout.DeleteUserEntity
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeleteUserResponse(
+    val status: Int,
+    val code: String,
+    val message: String,
+    val data: DeleteUserData
+)
+
+@Serializable
+data class DeleteUserData(
+    val value: String?
+)
+
+fun DeleteUserResponse.toDeleteUserEntity(): DeleteUserEntity {
+    return DeleteUserEntity(
+        status = this.status,
+        code = this.code,
+        message = this.message,
+        data = DeleteUser(
+            value = this.data.value
+        )
+    )
+}

--- a/data/src/main/java/com/meongmoryteam/data/model/response/logout/PostUserLogoutResponse.kt
+++ b/data/src/main/java/com/meongmoryteam/data/model/response/logout/PostUserLogoutResponse.kt
@@ -1,0 +1,29 @@
+package com.meongmoryteam.data.model.response.logout
+
+import com.meongmoryteam.domain.model.response.logout.PostUserLogoutData
+import com.meongmoryteam.domain.model.response.logout.PostUserLogoutEntity
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PostUserLogoutResponse(
+    val status: Int,
+    val code: String,
+    val message: String,
+    val data: LogoutData
+)
+
+@Serializable
+data class LogoutData(
+    val value: String?,
+)
+
+fun PostUserLogoutResponse.toPostUserLogoutEntity(): PostUserLogoutEntity {
+    return PostUserLogoutEntity(
+        status = this.status,
+        code = this.code,
+        message = this.message,
+        data = PostUserLogoutData(
+            value = this.data.value
+        )
+    )
+}

--- a/data/src/main/java/com/meongmoryteam/data/model/response/mypage/GetUserMyPageResponse.kt
+++ b/data/src/main/java/com/meongmoryteam/data/model/response/mypage/GetUserMyPageResponse.kt
@@ -1,0 +1,35 @@
+package com.meongmoryteam.data.model.response.mypage
+
+import com.meongmoryteam.domain.model.response.mypage.GetUserMyPageData
+import com.meongmoryteam.domain.model.response.mypage.GetUserMyPageEntity
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetUserMyPageResponse(
+    val status: Int,
+    val code: String,
+    val message: String,
+    val data: Data
+)
+
+@Serializable
+data class Data(
+    val myPageUrl: String,
+    val nickname: String,
+    val phone: String,
+    val userIdx: Int,
+)
+
+fun GetUserMyPageResponse.toUserMyPageEntity(): GetUserMyPageEntity {
+    return GetUserMyPageEntity(
+        status = this.status,
+        code = this.code,
+        message = this.message,
+        getUserMyPageData = GetUserMyPageData(
+            myPageUrl = this.data.myPageUrl,
+            nickname = this.data.nickname,
+            phone = this.data.phone,
+            userIdx = this.data.userIdx
+        )
+    )
+}

--- a/data/src/main/java/com/meongmoryteam/data/model/response/mypage/PatchUserMyPageResponse.kt
+++ b/data/src/main/java/com/meongmoryteam/data/model/response/mypage/PatchUserMyPageResponse.kt
@@ -1,0 +1,21 @@
+package com.meongmoryteam.data.model.response.mypage
+
+import com.meongmoryteam.domain.model.response.mypage.PatchUserMyPageEntity
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PatchUserMyPageResponse(
+    val status: Int,
+    val code: String,
+    val message: String,
+    val data: String
+)
+
+fun PatchUserMyPageResponse.toUserMyPageEntity(): PatchUserMyPageEntity {
+    return PatchUserMyPageEntity(
+        status = this.status,
+        code = this.code,
+        message = this.message,
+        patchUserMyPageData = this.data
+    )
+}

--- a/data/src/main/java/com/meongmoryteam/data/repository/logout/LogoutRepositoryImpl.kt
+++ b/data/src/main/java/com/meongmoryteam/data/repository/logout/LogoutRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.meongmoryteam.data.repository.logout
+
+import com.meongmoryteam.data.datasource.logout.LogoutDataSource
+import com.meongmoryteam.data.model.response.logout.toPostUserLogoutEntity
+import com.meongmoryteam.domain.model.response.logout.PostUserLogoutEntity
+import com.meongmoryteam.domain.repository.logout.LogoutRepository
+import javax.inject.Inject
+
+class LogoutRepositoryImpl @Inject constructor(
+    private val logoutDataSource: LogoutDataSource
+) : LogoutRepository {
+    override suspend fun postUserLogout(): Result<PostUserLogoutEntity> {
+        return logoutDataSource.postUserLogout().map { it.toPostUserLogoutEntity() }
+    }
+}

--- a/data/src/main/java/com/meongmoryteam/data/repository/logout/LogoutRepositoryImpl.kt
+++ b/data/src/main/java/com/meongmoryteam/data/repository/logout/LogoutRepositoryImpl.kt
@@ -1,7 +1,9 @@
 package com.meongmoryteam.data.repository.logout
 
 import com.meongmoryteam.data.datasource.logout.LogoutDataSource
+import com.meongmoryteam.data.model.response.logout.toDeleteUserEntity
 import com.meongmoryteam.data.model.response.logout.toPostUserLogoutEntity
+import com.meongmoryteam.domain.model.response.logout.DeleteUserEntity
 import com.meongmoryteam.domain.model.response.logout.PostUserLogoutEntity
 import com.meongmoryteam.domain.repository.logout.LogoutRepository
 import javax.inject.Inject
@@ -11,5 +13,9 @@ class LogoutRepositoryImpl @Inject constructor(
 ) : LogoutRepository {
     override suspend fun postUserLogout(): Result<PostUserLogoutEntity> {
         return logoutDataSource.postUserLogout().map { it.toPostUserLogoutEntity() }
+    }
+
+    override suspend fun deleteUser(): Result<DeleteUserEntity> {
+        return logoutDataSource.deleteUser().map { it.toDeleteUserEntity() }
     }
 }

--- a/data/src/main/java/com/meongmoryteam/data/repository/mypage/MyPageRepositoryImpl.kt
+++ b/data/src/main/java/com/meongmoryteam/data/repository/mypage/MyPageRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.meongmoryteam.data.repository.mypage
+
+import com.meongmoryteam.data.datasource.mypage.MyPageDataSource
+import com.meongmoryteam.data.model.response.mypage.toUserMyPageEntity
+import com.meongmoryteam.domain.model.response.mypage.GetUserMyPageEntity
+import com.meongmoryteam.domain.repository.mypage.MyPageRepository
+import javax.inject.Inject
+
+class MyPageRepositoryImpl @Inject constructor(
+    private val myPageDataSource: MyPageDataSource
+) : MyPageRepository {
+    override suspend fun getUserMyPage(): Result<GetUserMyPageEntity> {
+        return myPageDataSource.getUserMyPage().map { it.toUserMyPageEntity() }
+    }
+}

--- a/data/src/main/java/com/meongmoryteam/data/repository/mypage/MyPageRepositoryImpl.kt
+++ b/data/src/main/java/com/meongmoryteam/data/repository/mypage/MyPageRepositoryImpl.kt
@@ -1,8 +1,11 @@
 package com.meongmoryteam.data.repository.mypage
 
 import com.meongmoryteam.data.datasource.mypage.MyPageDataSource
+import com.meongmoryteam.data.model.request.mypage.toUserMyPageRequest
 import com.meongmoryteam.data.model.response.mypage.toUserMyPageEntity
+import com.meongmoryteam.domain.model.reqeust.mypage.UserMyPageRequestEntity
 import com.meongmoryteam.domain.model.response.mypage.GetUserMyPageEntity
+import com.meongmoryteam.domain.model.response.mypage.PatchUserMyPageEntity
 import com.meongmoryteam.domain.repository.mypage.MyPageRepository
 import javax.inject.Inject
 
@@ -11,5 +14,9 @@ class MyPageRepositoryImpl @Inject constructor(
 ) : MyPageRepository {
     override suspend fun getUserMyPage(): Result<GetUserMyPageEntity> {
         return myPageDataSource.getUserMyPage().map { it.toUserMyPageEntity() }
+    }
+
+    override suspend fun patchUserMyPage(userMyPageRequestEntity: UserMyPageRequestEntity): Result<PatchUserMyPageEntity> {
+        return myPageDataSource.patchUserMyPage(userMyPageRequestEntity.toUserMyPageRequest()).map { it.toUserMyPageEntity() }
     }
 }

--- a/data/src/main/java/com/meongmoryteam/data/service/logout/LogoutApi.kt
+++ b/data/src/main/java/com/meongmoryteam/data/service/logout/LogoutApi.kt
@@ -1,0 +1,10 @@
+package com.meongmoryteam.data.service.logout
+
+import com.meongmoryteam.data.model.response.logout.PostUserLogoutResponse
+import retrofit2.http.POST
+
+interface LogoutApi {
+    @POST("users/logout")
+    suspend fun postUserLogout(
+    ): PostUserLogoutResponse
+}

--- a/data/src/main/java/com/meongmoryteam/data/service/logout/LogoutApi.kt
+++ b/data/src/main/java/com/meongmoryteam/data/service/logout/LogoutApi.kt
@@ -1,10 +1,15 @@
 package com.meongmoryteam.data.service.logout
 
+import com.meongmoryteam.data.model.response.logout.DeleteUserResponse
 import com.meongmoryteam.data.model.response.logout.PostUserLogoutResponse
+import retrofit2.http.DELETE
 import retrofit2.http.POST
 
 interface LogoutApi {
     @POST("users/logout")
     suspend fun postUserLogout(
     ): PostUserLogoutResponse
+
+    @DELETE("users")
+    suspend fun deleteUser(): DeleteUserResponse
 }

--- a/data/src/main/java/com/meongmoryteam/data/service/mypage/MyPageApi.kt
+++ b/data/src/main/java/com/meongmoryteam/data/service/mypage/MyPageApi.kt
@@ -1,7 +1,9 @@
 package com.meongmoryteam.data.service.mypage
 
+import com.meongmoryteam.data.model.request.mypage.UserMyPageRequest
 import com.meongmoryteam.data.model.response.mypage.GetUserMyPageResponse
 import com.meongmoryteam.data.model.response.mypage.PatchUserMyPageResponse
+import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 
@@ -10,5 +12,7 @@ interface MyPageApi {
     suspend fun getUserMyPage(): GetUserMyPageResponse
 
     @PATCH("users/myPage")
-    suspend fun patchUserMyPage(): PatchUserMyPageResponse
+    suspend fun patchUserMyPage(
+        @Body userMyPageRequest: UserMyPageRequest
+    ): PatchUserMyPageResponse
 }

--- a/data/src/main/java/com/meongmoryteam/data/service/mypage/MyPageApi.kt
+++ b/data/src/main/java/com/meongmoryteam/data/service/mypage/MyPageApi.kt
@@ -4,6 +4,6 @@ import com.meongmoryteam.data.model.response.mypage.GetUserMyPageResponse
 import retrofit2.http.GET
 
 interface MyPageApi {
-    @GET("user/myPage")
+    @GET("users/myPage")
     suspend fun getUserMyPage(): GetUserMyPageResponse
 }

--- a/data/src/main/java/com/meongmoryteam/data/service/mypage/MyPageApi.kt
+++ b/data/src/main/java/com/meongmoryteam/data/service/mypage/MyPageApi.kt
@@ -1,0 +1,9 @@
+package com.meongmoryteam.data.service.mypage
+
+import com.meongmoryteam.data.model.response.mypage.GetUserMyPageResponse
+import retrofit2.http.GET
+
+interface MyPageApi {
+    @GET("user/myPage")
+    suspend fun getUserMyPage(): GetUserMyPageResponse
+}

--- a/data/src/main/java/com/meongmoryteam/data/service/mypage/MyPageApi.kt
+++ b/data/src/main/java/com/meongmoryteam/data/service/mypage/MyPageApi.kt
@@ -1,9 +1,14 @@
 package com.meongmoryteam.data.service.mypage
 
 import com.meongmoryteam.data.model.response.mypage.GetUserMyPageResponse
+import com.meongmoryteam.data.model.response.mypage.PatchUserMyPageResponse
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 
 interface MyPageApi {
     @GET("users/myPage")
     suspend fun getUserMyPage(): GetUserMyPageResponse
+
+    @PATCH("users/myPage")
+    suspend fun patchUserMyPage(): PatchUserMyPageResponse
 }

--- a/domain/src/main/java/com/meongmoryteam/domain/model/reqeust/mypage/UserMyPageRequestEntity.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/model/reqeust/mypage/UserMyPageRequestEntity.kt
@@ -1,0 +1,5 @@
+package com.meongmoryteam.domain.model.reqeust.mypage
+
+data class UserMyPageRequestEntity(
+    val nickname: String
+)

--- a/domain/src/main/java/com/meongmoryteam/domain/model/response/logout/DeleteUserEntity.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/model/response/logout/DeleteUserEntity.kt
@@ -1,0 +1,12 @@
+package com.meongmoryteam.domain.model.response.logout
+
+data class DeleteUserEntity(
+    val status: Int,
+    val code: String,
+    val message: String,
+    val data: DeleteUser
+)
+
+data class DeleteUser(
+    val value: String?
+)

--- a/domain/src/main/java/com/meongmoryteam/domain/model/response/logout/PostUserLogoutEntity.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/model/response/logout/PostUserLogoutEntity.kt
@@ -1,0 +1,12 @@
+package com.meongmoryteam.domain.model.response.logout
+
+data class PostUserLogoutEntity(
+    val status: Int,
+    val code: String,
+    val message: String,
+    val data: PostUserLogoutData
+)
+
+data class PostUserLogoutData(
+    val value: String?
+)

--- a/domain/src/main/java/com/meongmoryteam/domain/model/response/mypage/GetUserMyPageEntity.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/model/response/mypage/GetUserMyPageEntity.kt
@@ -1,0 +1,15 @@
+package com.meongmoryteam.domain.model.response.mypage
+
+data class GetUserMyPageEntity(
+    val status: Int,
+    val code: String,
+    val message: String,
+    val getSmsSendData: GetUserMyPageData,
+)
+
+data class GetUserMyPageData(
+    val myPageUrl: String,
+    val nickname: String,
+    val phone: String,
+    val userIdx: Int,
+)

--- a/domain/src/main/java/com/meongmoryteam/domain/model/response/mypage/GetUserMyPageEntity.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/model/response/mypage/GetUserMyPageEntity.kt
@@ -4,7 +4,7 @@ data class GetUserMyPageEntity(
     val status: Int,
     val code: String,
     val message: String,
-    val getSmsSendData: GetUserMyPageData,
+    val getUserMyPageData: GetUserMyPageData,
 )
 
 data class GetUserMyPageData(

--- a/domain/src/main/java/com/meongmoryteam/domain/model/response/mypage/PatchUserMyPageEntity.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/model/response/mypage/PatchUserMyPageEntity.kt
@@ -1,0 +1,8 @@
+package com.meongmoryteam.domain.model.response.mypage
+
+data class PatchUserMyPageEntity(
+    val status: Int,
+    val code: String,
+    val message: String,
+    val patchUserMyPageData: String
+)

--- a/domain/src/main/java/com/meongmoryteam/domain/repository/logout/LogoutRepository.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/repository/logout/LogoutRepository.kt
@@ -1,7 +1,9 @@
 package com.meongmoryteam.domain.repository.logout
 
+import com.meongmoryteam.domain.model.response.logout.DeleteUserEntity
 import com.meongmoryteam.domain.model.response.logout.PostUserLogoutEntity
 
 interface LogoutRepository {
     suspend fun postUserLogout(): Result<PostUserLogoutEntity>
+    suspend fun deleteUser(): Result<DeleteUserEntity>
 }

--- a/domain/src/main/java/com/meongmoryteam/domain/repository/logout/LogoutRepository.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/repository/logout/LogoutRepository.kt
@@ -1,0 +1,7 @@
+package com.meongmoryteam.domain.repository.logout
+
+import com.meongmoryteam.domain.model.response.logout.PostUserLogoutEntity
+
+interface LogoutRepository {
+    suspend fun postUserLogout(): Result<PostUserLogoutEntity>
+}

--- a/domain/src/main/java/com/meongmoryteam/domain/repository/mypage/MyPageRepository.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/repository/mypage/MyPageRepository.kt
@@ -1,0 +1,7 @@
+package com.meongmoryteam.domain.repository.mypage
+
+import com.meongmoryteam.domain.model.response.mypage.GetUserMyPageEntity
+
+interface MyPageRepository {
+    suspend fun getUserMyPage(): Result<GetUserMyPageEntity>
+}

--- a/domain/src/main/java/com/meongmoryteam/domain/repository/mypage/MyPageRepository.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/repository/mypage/MyPageRepository.kt
@@ -1,7 +1,10 @@
 package com.meongmoryteam.domain.repository.mypage
 
+import com.meongmoryteam.domain.model.reqeust.mypage.UserMyPageRequestEntity
 import com.meongmoryteam.domain.model.response.mypage.GetUserMyPageEntity
+import com.meongmoryteam.domain.model.response.mypage.PatchUserMyPageEntity
 
 interface MyPageRepository {
     suspend fun getUserMyPage(): Result<GetUserMyPageEntity>
+    suspend fun patchUserMyPage(userMyPageRequestEntity: UserMyPageRequestEntity): Result<PatchUserMyPageEntity>
 }

--- a/domain/src/main/java/com/meongmoryteam/domain/usecase/login/GetUserMyPageUseCase.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/usecase/login/GetUserMyPageUseCase.kt
@@ -1,0 +1,10 @@
+package com.meongmoryteam.domain.usecase.login
+
+import com.meongmoryteam.domain.repository.mypage.MyPageRepository
+import javax.inject.Inject
+
+class GetUserMyPageUseCase @Inject constructor(
+    private val myPageRepository: MyPageRepository
+) {
+    suspend operator fun invoke() = myPageRepository.getUserMyPage()
+}

--- a/domain/src/main/java/com/meongmoryteam/domain/usecase/logout/DeleteUserUseCase.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/usecase/logout/DeleteUserUseCase.kt
@@ -1,0 +1,11 @@
+package com.meongmoryteam.domain.usecase.logout
+
+import com.meongmoryteam.domain.repository.logout.LogoutRepository
+import javax.inject.Inject
+
+class DeleteUserUseCase @Inject constructor(
+    private val deleteUserRepository: LogoutRepository
+) {
+    suspend operator fun invoke()
+        = deleteUserRepository.deleteUser()
+}

--- a/domain/src/main/java/com/meongmoryteam/domain/usecase/logout/PostUserLogoutUseCase.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/usecase/logout/PostUserLogoutUseCase.kt
@@ -1,0 +1,11 @@
+package com.meongmoryteam.domain.usecase.logout
+
+import com.meongmoryteam.domain.repository.logout.LogoutRepository
+import javax.inject.Inject
+
+class PostUserLogoutUseCase @Inject constructor(
+    private val logoutRepository: LogoutRepository
+) {
+    suspend operator fun invoke()
+        = logoutRepository.postUserLogout()
+}

--- a/domain/src/main/java/com/meongmoryteam/domain/usecase/mypage/GetUserMyPageUseCase.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/usecase/mypage/GetUserMyPageUseCase.kt
@@ -1,4 +1,4 @@
-package com.meongmoryteam.domain.usecase.login
+package com.meongmoryteam.domain.usecase.mypage
 
 import com.meongmoryteam.domain.repository.mypage.MyPageRepository
 import javax.inject.Inject

--- a/domain/src/main/java/com/meongmoryteam/domain/usecase/mypage/PatchUserMyPageUseCase.kt
+++ b/domain/src/main/java/com/meongmoryteam/domain/usecase/mypage/PatchUserMyPageUseCase.kt
@@ -1,0 +1,12 @@
+package com.meongmoryteam.domain.usecase.mypage
+
+import com.meongmoryteam.domain.model.reqeust.mypage.UserMyPageRequestEntity
+import com.meongmoryteam.domain.repository.mypage.MyPageRepository
+import javax.inject.Inject
+
+class PatchUserMyPageUseCase @Inject constructor(
+    private val myPageRepository: MyPageRepository
+) {
+    suspend operator fun invoke(userMyPageRequestEntity: UserMyPageRequestEntity)
+        = myPageRepository.patchUserMyPage(userMyPageRequestEntity)
+}

--- a/presentation/src/main/java/com/meongmoryteam/presentation/base/CustomDialog.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/base/CustomDialog.kt
@@ -154,7 +154,8 @@ fun LogoutAlertDialog(
 // 탈퇴 다이어로그
 @Composable
 fun SecessionAlertDialog(
-    openDialogCustom: MutableState<Boolean>
+    openDialogCustom: MutableState<Boolean>,
+    viewModel: MyPageViewModel = hiltViewModel()
 ) {
     Dialog(
         onDismissRequest = { openDialogCustom.value = false }
@@ -165,7 +166,9 @@ fun SecessionAlertDialog(
             leftButton = stringResource(R.string.dialog_cancel),
             rightButton = stringResource(R.string.dialog_secession_yes),
             dialogCustom = openDialogCustom,
-            onRightButtonClick = { }
+            onRightButtonClick = {
+                viewModel.setEvent(MyPageContract.MyPageEvent.OnClickDeleteUserButtonClicked)
+            }
         )
     }
 }

--- a/presentation/src/main/java/com/meongmoryteam/presentation/base/CustomDialog.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/base/CustomDialog.kt
@@ -42,7 +42,6 @@ private fun CustomDialogUI(
     leftButton: String? = null,
     rightButton: String? = null,
     dialogCustom: MutableState<Boolean>,
-    viewModel: MyPageViewModel = hiltViewModel(),
     onRightButtonClick: () -> Unit
 ) {
     Card(

--- a/presentation/src/main/java/com/meongmoryteam/presentation/base/CustomDialog.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/base/CustomDialog.kt
@@ -26,7 +26,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.meongmoryteam.presentation.R
+import com.meongmoryteam.presentation.ui.myPage.MyPageContract
+import com.meongmoryteam.presentation.ui.myPage.MyPageViewModel
 import com.meongmoryteam.presentation.ui.theme.DialogBackground
 import com.meongmoryteam.presentation.ui.theme.DialogStroke
 import com.meongmoryteam.presentation.ui.theme.DialogTextBlue
@@ -38,7 +41,9 @@ private fun CustomDialogUI(
     textDetail: String? = null,
     leftButton: String? = null,
     rightButton: String? = null,
-    dialogCustom: MutableState<Boolean>
+    dialogCustom: MutableState<Boolean>,
+    viewModel: MyPageViewModel = hiltViewModel(),
+    onRightButtonClick: () -> Unit
 ) {
     Card(
         shape = RoundedCornerShape(14.dp),
@@ -84,9 +89,10 @@ private fun CustomDialogUI(
                 Arrangement.SpaceEvenly
             ) {
 
-                TextButton(onClick = {
-                    dialogCustom.value = false
-                }) {
+                TextButton(
+                    onClick = {
+                        dialogCustom.value = false
+                    }) {
                     leftButton?.let {
                         Text(
                             leftButton,
@@ -101,9 +107,12 @@ private fun CustomDialogUI(
                         .width(1.dp)
                         .background(DialogStroke.copy(0.36f))
                 )
-                TextButton(onClick = {
-                    dialogCustom.value = true
-                }) {
+                TextButton(
+                    onClick = {
+                        dialogCustom.value = true
+                        onRightButtonClick()
+                    }
+                ) {
                     rightButton?.let {
                         Text(
                             rightButton,
@@ -121,7 +130,8 @@ private fun CustomDialogUI(
 // 로그아웃 다이어로그
 @Composable
 fun LogoutAlertDialog(
-    openDialogCustom: MutableState<Boolean>
+    openDialogCustom: MutableState<Boolean>,
+    viewModel: MyPageViewModel = hiltViewModel()
 ) {
     Dialog(
         onDismissRequest = { openDialogCustom.value = false }
@@ -131,7 +141,12 @@ fun LogoutAlertDialog(
             textDetail = stringResource(R.string.dialog_logout_detail),
             leftButton = stringResource(R.string.dialog_cancel),
             rightButton = stringResource(R.string.dialog_logout),
-            dialogCustom = openDialogCustom
+            dialogCustom = openDialogCustom,
+            onRightButtonClick = {
+                // 오른쪽 버튼 클릭 시 viewModel 호출
+                viewModel.setEvent(MyPageContract.MyPageEvent.OnClickLogoutButtonClicked)
+                openDialogCustom.value = false  // 다이얼로그 닫기
+            }
         )
     }
 }
@@ -150,7 +165,8 @@ fun SecessionAlertDialog(
             textDetail = stringResource(R.string.dialog_secession_detail),
             leftButton = stringResource(R.string.dialog_cancel),
             rightButton = stringResource(R.string.dialog_secession_yes),
-            dialogCustom = openDialogCustom
+            dialogCustom = openDialogCustom,
+            onRightButtonClick = { }
         )
     }
 }

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/main/MainScreen.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/main/MainScreen.kt
@@ -13,15 +13,18 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import com.meongmoryteam.presentation.ui.bottom.MeongMoryBottomNavigation
 import com.meongmoryteam.presentation.ui.bottom.MeongMoryRoute
 import com.meongmoryteam.presentation.ui.bottom.navigateBottomNavigationScreen
 import com.meongmoryteam.presentation.ui.home.HomeScreen
+import com.meongmoryteam.presentation.ui.login.LoginActivity
 import com.meongmoryteam.presentation.ui.map.MapScreen
 import com.meongmoryteam.presentation.ui.myPage.MyPageScreen
 import com.meongmoryteam.presentation.ui.myPage.profile.MyPageProfileScreen
 import com.meongmoryteam.presentation.ui.myPage.question.MyPageQuestionScreen
+import com.meongmoryteam.presentation.ui.register_family.RouteScreen
 
 @Composable
 fun MainScreen(
@@ -61,6 +64,7 @@ fun MainScreen(
                 MyPageScreen(
                     navigateToEditNickNameScreen = { navController.navigate(MeongMoryRoute.EDIT_NICKNAME.route) },
                     navigateToQuestionScreen = { navController.navigate(MeongMoryRoute.QUESTION.route) },
+                    navigateToLoginScreen = { navController.navigate(MeongMoryRoute.HOME.route) }
                 )
             }
             composable(route = MeongMoryRoute.EDIT_NICKNAME.route) {

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageContract.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageContract.kt
@@ -15,11 +15,13 @@ class MyPageContract {
     sealed class MyPageSideEffect : ViewSideEffect {
         object NavigateToEditProfile : MyPageSideEffect()
         object NavigateToQuestion : MyPageSideEffect()
+        object NavigateToLogin : MyPageSideEffect()
     }
 
     sealed class MyPageEvent : ViewEvent {
         object InitMyPageScreen : MyPageEvent()
         object OnClickProfileEditButtonClicked : MyPageEvent()
         object OnQuestionClicked : MyPageEvent()
+        object OnClickLogoutButtonClicked: MyPageEvent()
     }
 }

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageContract.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageContract.kt
@@ -23,5 +23,6 @@ class MyPageContract {
         object OnClickProfileEditButtonClicked : MyPageEvent()
         object OnQuestionClicked : MyPageEvent()
         object OnClickLogoutButtonClicked: MyPageEvent()
+        object OnClickDeleteUserButtonClicked: MyPageEvent()
     }
 }

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageScreen.kt
@@ -54,6 +54,7 @@ fun MyPageScreen(
     viewModel: MyPageViewModel = hiltViewModel(),
     navigateToEditNickNameScreen: () -> Unit,
     navigateToQuestionScreen: () -> Unit,
+    navigateToLoginScreen: () -> Unit
 ) {
     LaunchedEffect(true) {
         viewModel.setEvent(MyPageContract.MyPageEvent.InitMyPageScreen)
@@ -68,6 +69,10 @@ fun MyPageScreen(
 
                 is MyPageContract.MyPageSideEffect.NavigateToQuestion -> {
                     navigateToQuestionScreen()
+                }
+
+                is MyPageContract.MyPageSideEffect.NavigateToLogin -> {
+                    navigateToLoginScreen()
                 }
             }
         }
@@ -198,7 +203,7 @@ fun MyPageScreen(
                     R.drawable.ic_logout,
                     stringResource(R.string.my_page_logout),
                     stringResource(R.string.my_page_logout),
-                    onClick = { },
+                    onClick = {  },
                 )
                 ListButton(
                     R.drawable.ic_user,
@@ -400,6 +405,7 @@ fun MyPageScreen(
             MyPageScreen(
                 navigateToEditNickNameScreen = { },
                 navigateToQuestionScreen = { },
+                navigateToLoginScreen = { }
             )
         }
     }

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageScreen.kt
@@ -309,7 +309,9 @@ fun MyPageScreen(
         // 버튼마다 다른 다이어로그
         if (refreshButton.value) {
             if (onClickAction == stringResource(R.string.my_page_profile_edit)) {
-                LogoutAlertDialog(openDialogCustom = refreshButton)
+                LogoutAlertDialog(
+                    openDialogCustom = refreshButton
+                )
             }
             if (onClickAction == stringResource(R.string.my_page_question)) {
                 SecessionAlertDialog(openDialogCustom = refreshButton)

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageViewModel.kt
@@ -1,17 +1,21 @@
 package com.meongmoryteam.presentation.ui.myPage
 
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.viewModelScope
+import com.meongmoryteam.domain.usecase.login.GetUserMyPageUseCase
 import com.meongmoryteam.presentation.base.BaseViewModel
 import com.meongmoryteam.presentation.base.LoadState
 import com.meongmoryteam.presentation.ui.myPage.MyPageContract.MyPageEvent
 import com.meongmoryteam.presentation.ui.myPage.MyPageContract.MyPageSideEffect
 import com.meongmoryteam.presentation.ui.myPage.MyPageContract.MyPageViewState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
+    private val getUserMyPageUseCase: GetUserMyPageUseCase,
 ) : BaseViewModel<MyPageViewState, MyPageSideEffect, MyPageEvent>(
     MyPageViewState()
 ) {
@@ -29,6 +33,24 @@ class MyPageViewModel @Inject constructor(
 
             is MyPageEvent.OnQuestionClicked -> {
                 sendEffect({ MyPageSideEffect.NavigateToQuestion })
+            }
+        }
+    }
+
+    private fun getUserMyPage() {
+        viewModelScope.launch {
+            getUserMyPageUseCase().onSuccess {
+                updateState {
+                    copy(
+
+                    )
+                }
+            }.onFailure {
+                updateState {
+                    copy(
+
+                    )
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageViewModel.kt
@@ -2,6 +2,7 @@ package com.meongmoryteam.presentation.ui.myPage
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.viewModelScope
+import com.meongmoryteam.domain.usecase.logout.PostUserLogoutUseCase
 import com.meongmoryteam.domain.usecase.mypage.GetUserMyPageUseCase
 import com.meongmoryteam.presentation.base.BaseViewModel
 import com.meongmoryteam.presentation.base.LoadState
@@ -16,6 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val getUserMyPageUseCase: GetUserMyPageUseCase,
+    private val postUserLogoutUseCase: PostUserLogoutUseCase
 ) : BaseViewModel<MyPageViewState, MyPageSideEffect, MyPageEvent>(
     MyPageViewState()
 ) {
@@ -35,6 +37,11 @@ class MyPageViewModel @Inject constructor(
             is MyPageEvent.OnQuestionClicked -> {
                 sendEffect({ MyPageSideEffect.NavigateToQuestion })
             }
+
+            is MyPageEvent.OnClickLogoutButtonClicked -> {
+                postUserLogout()
+                sendEffect({ MyPageSideEffect.NavigateToLogin })
+            }
         }
     }
 
@@ -50,6 +57,18 @@ class MyPageViewModel @Inject constructor(
                 updateState {
                     copy(
                         loadState = LoadState.ERROR
+                    )
+                }
+            }
+        }
+    }
+
+    private fun postUserLogout() {
+        viewModelScope.launch {
+            postUserLogoutUseCase().onSuccess {
+                updateState {
+                    copy(
+                        loadState = LoadState.SUCCESS
                     )
                 }
             }

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageViewModel.kt
@@ -2,6 +2,7 @@ package com.meongmoryteam.presentation.ui.myPage
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.viewModelScope
+import com.meongmoryteam.domain.usecase.logout.DeleteUserUseCase
 import com.meongmoryteam.domain.usecase.logout.PostUserLogoutUseCase
 import com.meongmoryteam.domain.usecase.mypage.GetUserMyPageUseCase
 import com.meongmoryteam.presentation.base.BaseViewModel
@@ -17,7 +18,8 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val getUserMyPageUseCase: GetUserMyPageUseCase,
-    private val postUserLogoutUseCase: PostUserLogoutUseCase
+    private val postUserLogoutUseCase: PostUserLogoutUseCase,
+    private val postUserDeleteUserUseCase: DeleteUserUseCase
 ) : BaseViewModel<MyPageViewState, MyPageSideEffect, MyPageEvent>(
     MyPageViewState()
 ) {
@@ -40,6 +42,11 @@ class MyPageViewModel @Inject constructor(
 
             is MyPageEvent.OnClickLogoutButtonClicked -> {
                 postUserLogout()
+                sendEffect({ MyPageSideEffect.NavigateToLogin })
+            }
+
+            is MyPageEvent.OnClickDeleteUserButtonClicked -> {
+                postUserDelete()
                 sendEffect({ MyPageSideEffect.NavigateToLogin })
             }
         }
@@ -66,6 +73,18 @@ class MyPageViewModel @Inject constructor(
     private fun postUserLogout() {
         viewModelScope.launch {
             postUserLogoutUseCase().onSuccess {
+                updateState {
+                    copy(
+                        loadState = LoadState.SUCCESS
+                    )
+                }
+            }
+        }
+    }
+
+    private fun postUserDelete() {
+        viewModelScope.launch {
+            postUserDeleteUserUseCase().onSuccess {
                 updateState {
                     copy(
                         loadState = LoadState.SUCCESS

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageViewModel.kt
@@ -25,6 +25,7 @@ class MyPageViewModel @Inject constructor(
         when (event) {
             is MyPageEvent.InitMyPageScreen -> {
                 updateState { copy(loadState = LoadState.SUCCESS) }
+                getUserMyPage()
             }
 
             is MyPageEvent.OnClickProfileEditButtonClicked -> {
@@ -42,13 +43,13 @@ class MyPageViewModel @Inject constructor(
             getUserMyPageUseCase().onSuccess {
                 updateState {
                     copy(
-
+                        loadState = LoadState.SUCCESS
                     )
                 }
             }.onFailure {
                 updateState {
                     copy(
-
+                        loadState = LoadState.ERROR
                     )
                 }
             }

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/MyPageViewModel.kt
@@ -2,7 +2,7 @@ package com.meongmoryteam.presentation.ui.myPage
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.viewModelScope
-import com.meongmoryteam.domain.usecase.login.GetUserMyPageUseCase
+import com.meongmoryteam.domain.usecase.mypage.GetUserMyPageUseCase
 import com.meongmoryteam.presentation.base.BaseViewModel
 import com.meongmoryteam.presentation.base.LoadState
 import com.meongmoryteam.presentation.ui.myPage.MyPageContract.MyPageEvent

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/profile/MyPageProfileScreen.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/profile/MyPageProfileScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.meongmoryteam.domain.repository.mypage.MyPageRepository
+import com.meongmoryteam.domain.usecase.mypage.PatchUserMyPageUseCase
 import com.meongmoryteam.presentation.R
 import com.meongmoryteam.presentation.ui.theme.ButtonContent
 import com.meongmoryteam.presentation.ui.theme.EditChangeFill
@@ -277,7 +279,6 @@ fun ProfileChangeButton(
 fun PreviewProfileScreen() {
     MeongmoryTheme {
         MyPageProfileScreen(
-            viewModel = MyPageProfileViewModel(),
             navigateToPrevious = { }
         )
     }

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/profile/MyPageProfileScreen.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/profile/MyPageProfileScreen.kt
@@ -35,8 +35,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.meongmoryteam.domain.repository.mypage.MyPageRepository
-import com.meongmoryteam.domain.usecase.mypage.PatchUserMyPageUseCase
 import com.meongmoryteam.presentation.R
 import com.meongmoryteam.presentation.ui.theme.ButtonContent
 import com.meongmoryteam.presentation.ui.theme.EditChangeFill

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/profile/MyPageProfileScreen.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/profile/MyPageProfileScreen.kt
@@ -252,7 +252,9 @@ fun ProfileChangeButton(
 ) {
     Button(
         onClick = {
-            viewModel.setEvent(MyPageProfileContract.MyPageProfileEvent.OnClickPreviousButton)
+            if (isFilled && !isOverflow) {
+                viewModel.setEvent(MyPageProfileContract.MyPageProfileEvent.OnClickChangeButton)
+            }
         },
         colors = if (!isFilled || isOverflow) {
             ButtonDefaults.textButtonColors(LightGrey)

--- a/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/profile/MyPageProfileViewModel.kt
+++ b/presentation/src/main/java/com/meongmoryteam/presentation/ui/myPage/profile/MyPageProfileViewModel.kt
@@ -3,6 +3,8 @@ package com.meongmoryteam.presentation.ui.myPage.profile
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.viewModelScope
+import com.meongmoryteam.domain.model.reqeust.mypage.UserMyPageRequestEntity
+import com.meongmoryteam.domain.usecase.mypage.PatchUserMyPageUseCase
 import com.meongmoryteam.presentation.base.BaseViewModel
 import com.meongmoryteam.presentation.base.LoadState
 import com.meongmoryteam.presentation.ui.myPage.profile.MyPageProfileContract.MyPageProfileEvent
@@ -14,6 +16,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageProfileViewModel @Inject constructor(
+    private val patchUserMyPageUseCase: PatchUserMyPageUseCase,
 ) : BaseViewModel<MyPageProfileViewState, MyPageProfileSideEffect, MyPageProfileEvent>(
     MyPageProfileViewState()
 ) {
@@ -45,16 +48,27 @@ class MyPageProfileViewModel @Inject constructor(
         }
     }
 
-    private fun changeNickName(
-        nickName: String = viewState.value.nickName
-    ) = viewModelScope.launch {
-        updateState {
-            copy(
-                loadState = LoadState.SUCCESS,
-                nickName = nickName
+    private fun changeNickName() {
+        viewModelScope.launch {
+            val userNickNameRequest = UserMyPageRequestEntity(
+                viewState.value.nickName
             )
+            patchUserMyPageUseCase(userNickNameRequest).onSuccess {
+                updateState {
+                    copy(
+                        loadState = LoadState.SUCCESS,
+                        nickName = it.patchUserMyPageData
+                    )
+                }
+            }.onFailure {
+                updateState {
+                    copy(
+                        loadState = LoadState.ERROR
+                    )
+                }
+            }
+            sendEffect({ MyPageProfileSideEffect.NavigateToMyPageScreen })
         }
-        sendEffect({ MyPageProfileSideEffect.NavigateToMyPageScreen })
     }
 
     // 텍스트 길이 초과


### PR DESCRIPTION
## 주요 작업 내용
- 이슈번호 : #49 

## 작업 내용 정리
- 마이페이지 첫 로딩시 마이페이지 조회 API 호출
- 닉네임 변경 클릭시 마이페이지 수정 API 호출
- 로그아웃 다이어로그 클릭시 로그아웃 API 호출
- 회원탈퇴 다이어로그 클릭시 회원탈퇴 API 호출

## 변경점
- 마이페이지 첫 화면 로딩했을 때와 닉네임 변경, 로그아웃, 탈퇴 버튼을 각각 클릭했을 때 API를 호출하는 것 까진 구현했습니다, 이제 로그인 부분에서 사용자의 고유 id 값을 받아오게 되면 유저 id값을 쿼리값으로 반환하여 실제로 기능이 작동하도록 수정하겠습니다!
